### PR TITLE
feat: protect URL path integrity from unsafe interpolated values

### DIFF
--- a/__tests__/fixtures/docker/commands.ts
+++ b/__tests__/fixtures/docker/commands.ts
@@ -3,7 +3,7 @@
  *
  * WARN: Do not edit directly.
  *
- * Generated on 2026-03-06T07:45:59.608Z
+ * Generated on 2026-03-17T13:16:20.373Z
  *
  */
 /** eslint-disable max-classes */
@@ -238,6 +238,18 @@ import type {
 } from "./types.js";
 
 /**
+ * Tagged template literal that applies encodeURIComponent to all interpolated
+ * values, protecting path integrity from characters like `/` and `#`.
+ * @example encodePath`/users/${userId}` // "/users/foo%2Fbar"
+ */
+function encodePath(
+	strings: TemplateStringsArray,
+	...values: string[]
+): string {
+	return String.raw({ raw: strings }, ...values.map(encodeURIComponent));
+}
+
+/**
  * Returns a list of containers. For details on the format, see the
  * [inspect endpoint](#operation/ContainerInspect).
  *
@@ -300,7 +312,11 @@ export class ContainerInspectCommand extends Command<
 
 	constructor(input: ContainerInspectCommandInput) {
 		const { id, size } = input;
-		super(`/containers/${id}/json`, undefined, stripUndefined({ size }));
+		super(
+			encodePath`/containers/${id}/json`,
+			undefined,
+			stripUndefined({ size }),
+		);
 	}
 }
 
@@ -319,7 +335,11 @@ export class ContainerTopCommand extends Command<
 
 	constructor(input: ContainerTopCommandInput) {
 		const { id, ps_args } = input;
-		super(`/containers/${id}/top`, undefined, stripUndefined({ ps_args }));
+		super(
+			encodePath`/containers/${id}/top`,
+			undefined,
+			stripUndefined({ ps_args }),
+		);
 	}
 }
 
@@ -342,7 +362,7 @@ export class ContainerLogsCommand extends Command<
 		const { id, follow, stdout, stderr, since, until, timestamps, tail } =
 			input;
 		super(
-			`/containers/${id}/logs`,
+			encodePath`/containers/${id}/logs`,
 			undefined,
 			stripUndefined({
 				follow,
@@ -375,7 +395,7 @@ export class ContainerChangesCommand extends Command<
 
 	constructor(input: ContainerChangesCommandInput) {
 		const { id } = input;
-		super(`/containers/${id}/changes`);
+		super(encodePath`/containers/${id}/changes`);
 	}
 }
 
@@ -392,7 +412,7 @@ export class ContainerExportCommand extends Command<
 
 	constructor(input: ContainerExportCommandInput) {
 		const { id } = input;
-		super(`/containers/${id}/export`);
+		super(encodePath`/containers/${id}/export`);
 	}
 }
 
@@ -439,7 +459,7 @@ export class ContainerStatsCommand extends Command<
 	constructor(input: ContainerStatsCommandInput) {
 		const { id, stream, oneshot } = input;
 		super(
-			`/containers/${id}/stats`,
+			encodePath`/containers/${id}/stats`,
 			undefined,
 			stripUndefined({ stream, oneshot }),
 		);
@@ -460,7 +480,11 @@ export class ContainerResizeCommand extends Command<
 
 	constructor(input: ContainerResizeCommandInput) {
 		const { id, h, w } = input;
-		super(`/containers/${id}/resize`, undefined, stripUndefined({ h, w }));
+		super(
+			encodePath`/containers/${id}/resize`,
+			undefined,
+			stripUndefined({ h, w }),
+		);
 	}
 }
 
@@ -478,7 +502,11 @@ export class ContainerStartCommand extends Command<
 
 	constructor(input: ContainerStartCommandInput) {
 		const { id, detachKeys } = input;
-		super(`/containers/${id}/start`, undefined, stripUndefined({ detachKeys }));
+		super(
+			encodePath`/containers/${id}/start`,
+			undefined,
+			stripUndefined({ detachKeys }),
+		);
 	}
 }
 
@@ -496,7 +524,11 @@ export class ContainerStopCommand extends Command<
 
 	constructor(input: ContainerStopCommandInput) {
 		const { id, signal, t } = input;
-		super(`/containers/${id}/stop`, undefined, stripUndefined({ signal, t }));
+		super(
+			encodePath`/containers/${id}/stop`,
+			undefined,
+			stripUndefined({ signal, t }),
+		);
 	}
 }
 
@@ -515,7 +547,7 @@ export class ContainerRestartCommand extends Command<
 	constructor(input: ContainerRestartCommandInput) {
 		const { id, signal, t } = input;
 		super(
-			`/containers/${id}/restart`,
+			encodePath`/containers/${id}/restart`,
 			undefined,
 			stripUndefined({ signal, t }),
 		);
@@ -537,7 +569,11 @@ export class ContainerKillCommand extends Command<
 
 	constructor(input: ContainerKillCommandInput) {
 		const { id, signal } = input;
-		super(`/containers/${id}/kill`, undefined, stripUndefined({ signal }));
+		super(
+			encodePath`/containers/${id}/kill`,
+			undefined,
+			stripUndefined({ signal }),
+		);
 	}
 }
 
@@ -555,7 +591,7 @@ export class ContainerUpdateCommand extends Command<
 
 	constructor(input: ContainerUpdateCommandInput) {
 		const { id, ...body } = input;
-		super(`/containers/${id}/update`, jsonStringify(body));
+		super(encodePath`/containers/${id}/update`, jsonStringify(body));
 	}
 }
 
@@ -573,7 +609,11 @@ export class ContainerRenameCommand extends Command<
 
 	constructor(input: ContainerRenameCommandInput) {
 		const { id, name } = input;
-		super(`/containers/${id}/rename`, undefined, stripUndefined({ name }));
+		super(
+			encodePath`/containers/${id}/rename`,
+			undefined,
+			stripUndefined({ name }),
+		);
 	}
 }
 
@@ -595,7 +635,7 @@ export class ContainerPauseCommand extends Command<
 
 	constructor(input: ContainerPauseCommandInput) {
 		const { id } = input;
-		super(`/containers/${id}/pause`);
+		super(encodePath`/containers/${id}/pause`);
 	}
 }
 
@@ -612,7 +652,7 @@ export class ContainerUnpauseCommand extends Command<
 
 	constructor(input: ContainerUnpauseCommandInput) {
 		const { id } = input;
-		super(`/containers/${id}/unpause`);
+		super(encodePath`/containers/${id}/unpause`);
 	}
 }
 
@@ -728,7 +768,7 @@ export class ContainerAttachCommand extends Command<
 	constructor(input: ContainerAttachCommandInput) {
 		const { id, detachKeys, logs, stream, stdin, stdout, stderr } = input;
 		super(
-			`/containers/${id}/attach`,
+			encodePath`/containers/${id}/attach`,
 			undefined,
 			stripUndefined({ detachKeys, logs, stream, stdin, stdout, stderr }),
 		);
@@ -750,7 +790,7 @@ export class ContainerAttachWebsocketCommand extends Command<
 	constructor(input: ContainerAttachWebsocketCommandInput) {
 		const { id, detachKeys, logs, stream, stdin, stdout, stderr } = input;
 		super(
-			`/containers/${id}/attach/ws`,
+			encodePath`/containers/${id}/attach/ws`,
 			undefined,
 			stripUndefined({ detachKeys, logs, stream, stdin, stdout, stderr }),
 		);
@@ -771,7 +811,11 @@ export class ContainerWaitCommand extends Command<
 
 	constructor(input: ContainerWaitCommandInput) {
 		const { id, condition } = input;
-		super(`/containers/${id}/wait`, undefined, stripUndefined({ condition }));
+		super(
+			encodePath`/containers/${id}/wait`,
+			undefined,
+			stripUndefined({ condition }),
+		);
 	}
 }
 
@@ -789,7 +833,11 @@ export class ContainerDeleteCommand extends Command<
 
 	constructor(input: ContainerDeleteCommandInput) {
 		const { id, v, force, link } = input;
-		super(`/containers/${id}`, undefined, stripUndefined({ v, force, link }));
+		super(
+			encodePath`/containers/${id}`,
+			undefined,
+			stripUndefined({ v, force, link }),
+		);
 	}
 }
 
@@ -807,7 +855,11 @@ export class ContainerArchiveCommand extends Command<
 
 	constructor(input: ContainerArchiveCommandInput) {
 		const { id, path } = input;
-		super(`/containers/${id}/archive`, undefined, stripUndefined({ path }));
+		super(
+			encodePath`/containers/${id}/archive`,
+			undefined,
+			stripUndefined({ path }),
+		);
 	}
 }
 
@@ -830,7 +882,7 @@ export class PutContainerArchiveCommand extends Command<
 	constructor(input: PutContainerArchiveCommandInput) {
 		const { id, path, noOverwriteDirNonDir, copyUIDGID, body } = input;
 		super(
-			`/containers/${id}/archive`,
+			encodePath`/containers/${id}/archive`,
 			body,
 			stripUndefined({ path, noOverwriteDirNonDir, copyUIDGID }),
 		);
@@ -853,7 +905,11 @@ export class ContainerArchiveInfoCommand extends Command<
 
 	constructor(input: ContainerArchiveInfoCommandInput) {
 		const { id, path } = input;
-		super(`/containers/${id}/archive`, undefined, stripUndefined({ path }));
+		super(
+			encodePath`/containers/${id}/archive`,
+			undefined,
+			stripUndefined({ path }),
+		);
 	}
 }
 
@@ -1053,7 +1109,7 @@ export class ImageInspectCommand extends Command<
 
 	constructor(input: ImageInspectCommandInput) {
 		const { name } = input;
-		super(`/images/${name}/json`);
+		super(encodePath`/images/${name}/json`);
 	}
 }
 
@@ -1070,7 +1126,7 @@ export class ImageHistoryCommand extends Command<
 
 	constructor(input: ImageHistoryCommandInput) {
 		const { name } = input;
-		super(`/images/${name}/history`);
+		super(encodePath`/images/${name}/history`);
 	}
 }
 
@@ -1094,7 +1150,7 @@ export class ImagePushCommand extends Command<
 
 	constructor(input: ImagePushCommandInput) {
 		const { name, tag } = input;
-		super(`/images/${name}/push`, undefined, stripUndefined({ tag }));
+		super(encodePath`/images/${name}/push`, undefined, stripUndefined({ tag }));
 	}
 }
 
@@ -1112,7 +1168,11 @@ export class ImageTagCommand extends Command<
 
 	constructor(input: ImageTagCommandInput) {
 		const { name, repo, tag } = input;
-		super(`/images/${name}/tag`, undefined, stripUndefined({ repo, tag }));
+		super(
+			encodePath`/images/${name}/tag`,
+			undefined,
+			stripUndefined({ repo, tag }),
+		);
 	}
 }
 
@@ -1134,7 +1194,11 @@ export class ImageDeleteCommand extends Command<
 
 	constructor(input: ImageDeleteCommandInput) {
 		const { name, force, noprune } = input;
-		super(`/images/${name}`, undefined, stripUndefined({ force, noprune }));
+		super(
+			encodePath`/images/${name}`,
+			undefined,
+			stripUndefined({ force, noprune }),
+		);
 	}
 }
 
@@ -1378,7 +1442,7 @@ export class ImageGetCommand extends Command<ImageGetCommandInput, unknown> {
 
 	constructor(input: ImageGetCommandInput) {
 		const { name } = input;
-		super(`/images/${name}/get`);
+		super(encodePath`/images/${name}/get`);
 	}
 }
 
@@ -1444,7 +1508,7 @@ export class ContainerExecCommand extends Command<
 
 	constructor(input: ContainerExecCommandInput) {
 		const { id, ...body } = input;
-		super(`/containers/${id}/exec`, jsonStringify(body));
+		super(encodePath`/containers/${id}/exec`, jsonStringify(body));
 	}
 }
 
@@ -1460,7 +1524,7 @@ export class ExecStartCommand extends Command<ExecStartCommandInput, unknown> {
 
 	constructor(input: ExecStartCommandInput) {
 		const { id, ...body } = input;
-		super(`/exec/${id}/start`, jsonStringify(body));
+		super(encodePath`/exec/${id}/start`, jsonStringify(body));
 	}
 }
 
@@ -1479,7 +1543,7 @@ export class ExecResizeCommand extends Command<
 
 	constructor(input: ExecResizeCommandInput) {
 		const { id, h, w } = input;
-		super(`/exec/${id}/resize`, undefined, stripUndefined({ h, w }));
+		super(encodePath`/exec/${id}/resize`, undefined, stripUndefined({ h, w }));
 	}
 }
 
@@ -1496,7 +1560,7 @@ export class ExecInspectCommand extends Command<
 
 	constructor(input: ExecInspectCommandInput) {
 		const { id } = input;
-		super(`/exec/${id}/json`);
+		super(encodePath`/exec/${id}/json`);
 	}
 }
 
@@ -1548,7 +1612,7 @@ export class VolumeInspectCommand extends Command<
 
 	constructor(input: VolumeInspectCommandInput) {
 		const { name } = input;
-		super(`/volumes/${name}`);
+		super(encodePath`/volumes/${name}`);
 	}
 }
 
@@ -1566,7 +1630,11 @@ export class VolumeUpdateCommand extends Command<
 
 	constructor(input: VolumeUpdateCommandInput) {
 		const { name, version, ...body } = input;
-		super(`/volumes/${name}`, jsonStringify(body), stripUndefined({ version }));
+		super(
+			encodePath`/volumes/${name}`,
+			jsonStringify(body),
+			stripUndefined({ version }),
+		);
 	}
 }
 
@@ -1584,7 +1652,7 @@ export class VolumeDeleteCommand extends Command<
 
 	constructor(input: VolumeDeleteCommandInput) {
 		const { name, force } = input;
-		super(`/volumes/${name}`, undefined, stripUndefined({ force }));
+		super(encodePath`/volumes/${name}`, undefined, stripUndefined({ force }));
 	}
 }
 
@@ -1643,7 +1711,11 @@ export class NetworkInspectCommand extends Command<
 
 	constructor(input: NetworkInspectCommandInput) {
 		const { id, verbose, scope } = input;
-		super(`/networks/${id}`, undefined, stripUndefined({ verbose, scope }));
+		super(
+			encodePath`/networks/${id}`,
+			undefined,
+			stripUndefined({ verbose, scope }),
+		);
 	}
 }
 
@@ -1660,7 +1732,7 @@ export class NetworkDeleteCommand extends Command<
 
 	constructor(input: NetworkDeleteCommandInput) {
 		const { id } = input;
-		super(`/networks/${id}`);
+		super(encodePath`/networks/${id}`);
 	}
 }
 
@@ -1694,7 +1766,7 @@ export class NetworkConnectCommand extends Command<
 
 	constructor(input: NetworkConnectCommandInput) {
 		const { id, ...body } = input;
-		super(`/networks/${id}/connect`, jsonStringify(body));
+		super(encodePath`/networks/${id}/connect`, jsonStringify(body));
 	}
 }
 
@@ -1711,7 +1783,7 @@ export class NetworkDisconnectCommand extends Command<
 
 	constructor(input: NetworkDisconnectCommandInput) {
 		const { id, ...body } = input;
-		super(`/networks/${id}/disconnect`, jsonStringify(body));
+		super(encodePath`/networks/${id}/disconnect`, jsonStringify(body));
 	}
 }
 
@@ -1806,7 +1878,7 @@ export class PluginInspectCommand extends Command<
 
 	constructor(input: PluginInspectCommandInput) {
 		const { name } = input;
-		super(`/plugins/${name}/json`);
+		super(encodePath`/plugins/${name}/json`);
 	}
 }
 
@@ -1824,7 +1896,7 @@ export class PluginDeleteCommand extends Command<
 
 	constructor(input: PluginDeleteCommandInput) {
 		const { name, force } = input;
-		super(`/plugins/${name}`, undefined, stripUndefined({ force }));
+		super(encodePath`/plugins/${name}`, undefined, stripUndefined({ force }));
 	}
 }
 
@@ -1842,7 +1914,11 @@ export class PluginEnableCommand extends Command<
 
 	constructor(input: PluginEnableCommandInput) {
 		const { name, timeout } = input;
-		super(`/plugins/${name}/enable`, undefined, stripUndefined({ timeout }));
+		super(
+			encodePath`/plugins/${name}/enable`,
+			undefined,
+			stripUndefined({ timeout }),
+		);
 	}
 }
 
@@ -1860,7 +1936,11 @@ export class PluginDisableCommand extends Command<
 
 	constructor(input: PluginDisableCommandInput) {
 		const { name, force } = input;
-		super(`/plugins/${name}/disable`, undefined, stripUndefined({ force }));
+		super(
+			encodePath`/plugins/${name}/disable`,
+			undefined,
+			stripUndefined({ force }),
+		);
 	}
 }
 
@@ -1879,7 +1959,7 @@ export class PluginUpgradeCommand extends Command<
 	constructor(input: PluginUpgradeCommandInput) {
 		const { name, remote, ...body } = input;
 		super(
-			`/plugins/${name}/upgrade`,
+			encodePath`/plugins/${name}/upgrade`,
 			jsonStringify(body),
 			stripUndefined({ remote }),
 		);
@@ -1917,7 +1997,7 @@ export class PluginPushCommand extends Command<
 
 	constructor(input: PluginPushCommandInput) {
 		const { name } = input;
-		super(`/plugins/${name}/push`);
+		super(encodePath`/plugins/${name}/push`);
 	}
 }
 
@@ -1934,7 +2014,7 @@ export class PluginSetCommand extends Command<
 
 	constructor(input: PluginSetCommandInput) {
 		const { name, ...body } = input;
-		super(`/plugins/${name}/set`, jsonStringify(body));
+		super(encodePath`/plugins/${name}/set`, jsonStringify(body));
 	}
 }
 
@@ -1969,7 +2049,7 @@ export class NodeInspectCommand extends Command<
 
 	constructor(input: NodeInspectCommandInput) {
 		const { id } = input;
-		super(`/nodes/${id}`);
+		super(encodePath`/nodes/${id}`);
 	}
 }
 
@@ -1987,7 +2067,7 @@ export class NodeDeleteCommand extends Command<
 
 	constructor(input: NodeDeleteCommandInput) {
 		const { id, force } = input;
-		super(`/nodes/${id}`, undefined, stripUndefined({ force }));
+		super(encodePath`/nodes/${id}`, undefined, stripUndefined({ force }));
 	}
 }
 
@@ -2006,7 +2086,7 @@ export class NodeUpdateCommand extends Command<
 	constructor(input: NodeUpdateCommandInput) {
 		const { id, version, ...body } = input;
 		super(
-			`/nodes/${id}/update`,
+			encodePath`/nodes/${id}/update`,
 			jsonStringify(body),
 			stripUndefined({ version }),
 		);
@@ -2185,7 +2265,11 @@ export class ServiceInspectCommand extends Command<
 
 	constructor(input: ServiceInspectCommandInput) {
 		const { id, insertDefaults } = input;
-		super(`/services/${id}`, undefined, stripUndefined({ insertDefaults }));
+		super(
+			encodePath`/services/${id}`,
+			undefined,
+			stripUndefined({ insertDefaults }),
+		);
 	}
 }
 
@@ -2202,7 +2286,7 @@ export class ServiceDeleteCommand extends Command<
 
 	constructor(input: ServiceDeleteCommandInput) {
 		const { id } = input;
-		super(`/services/${id}`);
+		super(encodePath`/services/${id}`);
 	}
 }
 
@@ -2221,7 +2305,7 @@ export class ServiceUpdateCommand extends Command<
 	constructor(input: ServiceUpdateCommandInput) {
 		const { id, version, registryAuthFrom, rollback, ...body } = input;
 		super(
-			`/services/${id}/update`,
+			encodePath`/services/${id}/update`,
 			jsonStringify(body),
 			stripUndefined({ version, registryAuthFrom, rollback }),
 		);
@@ -2248,7 +2332,7 @@ export class ServiceLogsCommand extends Command<
 		const { id, details, follow, stdout, stderr, since, timestamps, tail } =
 			input;
 		super(
-			`/services/${id}/logs`,
+			encodePath`/services/${id}/logs`,
 			undefined,
 			stripUndefined({
 				details,
@@ -2294,7 +2378,7 @@ export class TaskInspectCommand extends Command<
 
 	constructor(input: TaskInspectCommandInput) {
 		const { id } = input;
-		super(`/tasks/${id}`);
+		super(encodePath`/tasks/${id}`);
 	}
 }
 
@@ -2318,7 +2402,7 @@ export class TaskLogsCommand extends Command<
 		const { id, details, follow, stdout, stderr, since, timestamps, tail } =
 			input;
 		super(
-			`/tasks/${id}/logs`,
+			encodePath`/tasks/${id}/logs`,
 			undefined,
 			stripUndefined({
 				details,
@@ -2381,7 +2465,7 @@ export class SecretInspectCommand extends Command<
 
 	constructor(input: SecretInspectCommandInput) {
 		const { id } = input;
-		super(`/secrets/${id}`);
+		super(encodePath`/secrets/${id}`);
 	}
 }
 
@@ -2398,7 +2482,7 @@ export class SecretDeleteCommand extends Command<
 
 	constructor(input: SecretDeleteCommandInput) {
 		const { id } = input;
-		super(`/secrets/${id}`);
+		super(encodePath`/secrets/${id}`);
 	}
 }
 
@@ -2417,7 +2501,7 @@ export class SecretUpdateCommand extends Command<
 	constructor(input: SecretUpdateCommandInput) {
 		const { id, version, ...body } = input;
 		super(
-			`/secrets/${id}/update`,
+			encodePath`/secrets/${id}/update`,
 			jsonStringify(body),
 			stripUndefined({ version }),
 		);
@@ -2472,7 +2556,7 @@ export class ConfigInspectCommand extends Command<
 
 	constructor(input: ConfigInspectCommandInput) {
 		const { id } = input;
-		super(`/configs/${id}`);
+		super(encodePath`/configs/${id}`);
 	}
 }
 
@@ -2489,7 +2573,7 @@ export class ConfigDeleteCommand extends Command<
 
 	constructor(input: ConfigDeleteCommandInput) {
 		const { id } = input;
-		super(`/configs/${id}`);
+		super(encodePath`/configs/${id}`);
 	}
 }
 
@@ -2508,7 +2592,7 @@ export class ConfigUpdateCommand extends Command<
 	constructor(input: ConfigUpdateCommandInput) {
 		const { id, version, ...body } = input;
 		super(
-			`/configs/${id}/update`,
+			encodePath`/configs/${id}/update`,
 			jsonStringify(body),
 			stripUndefined({ version }),
 		);
@@ -2528,7 +2612,7 @@ export class DistributionInspectCommand extends Command<
 
 	constructor(input: DistributionInspectCommandInput) {
 		const { name } = input;
-		super(`/distribution/${name}/json`);
+		super(encodePath`/distribution/${name}/json`);
 	}
 }
 

--- a/__tests__/fixtures/docker/hono-valibot.ts
+++ b/__tests__/fixtures/docker/hono-valibot.ts
@@ -3,7 +3,7 @@
  *
  * WARN: Do not edit directly.
  *
- * Generated on 2026-03-06T07:45:59.608Z
+ * Generated on 2026-03-17T13:16:20.373Z
  *
  */
 
@@ -172,14 +172,14 @@ function toPublicValibotHonoError(err: unknown): never {
 	throw err;
 }
 
-export const ContainerList = [
+export const containerList = [
 	validator("query", (value) => {
 		return v
 			.parseAsync(containerListCommandQuerySchema, value)
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const ContainerCreate = [
+export const containerCreate = [
 	validator("json", (value) => {
 		return v
 			.parseAsync(containerCreateCommandBodySchema, value)
@@ -191,7 +191,7 @@ export const ContainerCreate = [
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const ContainerInspect = [
+export const containerInspect = [
 	validator("param", (value) => {
 		return v
 			.parseAsync(containerInspectCommandParamsSchema, value)
@@ -203,7 +203,7 @@ export const ContainerInspect = [
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const ContainerTop = [
+export const containerTop = [
 	validator("param", (value) => {
 		return v
 			.parseAsync(containerTopCommandParamsSchema, value)
@@ -215,7 +215,7 @@ export const ContainerTop = [
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const ContainerLogs = [
+export const containerLogs = [
 	validator("param", (value) => {
 		return v
 			.parseAsync(containerLogsCommandParamsSchema, value)
@@ -227,21 +227,21 @@ export const ContainerLogs = [
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const ContainerChanges = [
+export const containerChanges = [
 	validator("param", (value) => {
 		return v
 			.parseAsync(containerChangesCommandParamsSchema, value)
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const ContainerExport = [
+export const containerExport = [
 	validator("param", (value) => {
 		return v
 			.parseAsync(containerExportCommandParamsSchema, value)
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const ContainerStats = [
+export const containerStats = [
 	validator("param", (value) => {
 		return v
 			.parseAsync(containerStatsCommandParamsSchema, value)
@@ -253,7 +253,7 @@ export const ContainerStats = [
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const ContainerResize = [
+export const containerResize = [
 	validator("param", (value) => {
 		return v
 			.parseAsync(containerResizeCommandParamsSchema, value)
@@ -265,7 +265,7 @@ export const ContainerResize = [
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const ContainerStart = [
+export const containerStart = [
 	validator("param", (value) => {
 		return v
 			.parseAsync(containerStartCommandParamsSchema, value)
@@ -277,7 +277,7 @@ export const ContainerStart = [
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const ContainerStop = [
+export const containerStop = [
 	validator("param", (value) => {
 		return v
 			.parseAsync(containerStopCommandParamsSchema, value)
@@ -289,7 +289,7 @@ export const ContainerStop = [
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const ContainerRestart = [
+export const containerRestart = [
 	validator("param", (value) => {
 		return v
 			.parseAsync(containerRestartCommandParamsSchema, value)
@@ -301,7 +301,7 @@ export const ContainerRestart = [
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const ContainerKill = [
+export const containerKill = [
 	validator("param", (value) => {
 		return v
 			.parseAsync(containerKillCommandParamsSchema, value)
@@ -313,7 +313,7 @@ export const ContainerKill = [
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const ContainerUpdate = [
+export const containerUpdate = [
 	validator("json", (value) => {
 		return v
 			.parseAsync(containerUpdateCommandBodySchema, value)
@@ -325,7 +325,7 @@ export const ContainerUpdate = [
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const ContainerRename = [
+export const containerRename = [
 	validator("param", (value) => {
 		return v
 			.parseAsync(containerRenameCommandParamsSchema, value)
@@ -337,21 +337,21 @@ export const ContainerRename = [
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const ContainerPause = [
+export const containerPause = [
 	validator("param", (value) => {
 		return v
 			.parseAsync(containerPauseCommandParamsSchema, value)
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const ContainerUnpause = [
+export const containerUnpause = [
 	validator("param", (value) => {
 		return v
 			.parseAsync(containerUnpauseCommandParamsSchema, value)
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const ContainerAttach = [
+export const containerAttach = [
 	validator("param", (value) => {
 		return v
 			.parseAsync(containerAttachCommandParamsSchema, value)
@@ -363,7 +363,7 @@ export const ContainerAttach = [
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const ContainerAttachWebsocket = [
+export const containerAttachWebsocket = [
 	validator("param", (value) => {
 		return v
 			.parseAsync(containerAttachWebsocketCommandParamsSchema, value)
@@ -375,7 +375,7 @@ export const ContainerAttachWebsocket = [
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const ContainerWait = [
+export const containerWait = [
 	validator("param", (value) => {
 		return v
 			.parseAsync(containerWaitCommandParamsSchema, value)
@@ -387,7 +387,7 @@ export const ContainerWait = [
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const ContainerDelete = [
+export const containerDelete = [
 	validator("param", (value) => {
 		return v
 			.parseAsync(containerDeleteCommandParamsSchema, value)
@@ -399,7 +399,7 @@ export const ContainerDelete = [
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const ContainerArchive = [
+export const containerArchive = [
 	validator("param", (value) => {
 		return v
 			.parseAsync(containerArchiveCommandParamsSchema, value)
@@ -411,7 +411,7 @@ export const ContainerArchive = [
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const PutContainerArchive = [
+export const putContainerArchive = [
 	validator("param", (value) => {
 		return v
 			.parseAsync(putContainerArchiveCommandParamsSchema, value)
@@ -423,7 +423,7 @@ export const PutContainerArchive = [
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const ContainerArchiveInfo = [
+export const containerArchiveInfo = [
 	validator("param", (value) => {
 		return v
 			.parseAsync(containerArchiveInfoCommandParamsSchema, value)
@@ -435,56 +435,56 @@ export const ContainerArchiveInfo = [
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const ContainerPrune = [
+export const containerPrune = [
 	validator("query", (value) => {
 		return v
 			.parseAsync(containerPruneCommandQuerySchema, value)
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const ImageList = [
+export const imageList = [
 	validator("query", (value) => {
 		return v
 			.parseAsync(imageListCommandQuerySchema, value)
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const ImageBuild = [
+export const imageBuild = [
 	validator("query", (value) => {
 		return v
 			.parseAsync(imageBuildCommandQuerySchema, value)
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const BuildPrune = [
+export const buildPrune = [
 	validator("query", (value) => {
 		return v
 			.parseAsync(buildPruneCommandQuerySchema, value)
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const ImageCreate = [
+export const imageCreate = [
 	validator("query", (value) => {
 		return v
 			.parseAsync(imageCreateCommandQuerySchema, value)
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const ImageInspect = [
+export const imageInspect = [
 	validator("param", (value) => {
 		return v
 			.parseAsync(imageInspectCommandParamsSchema, value)
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const ImageHistory = [
+export const imageHistory = [
 	validator("param", (value) => {
 		return v
 			.parseAsync(imageHistoryCommandParamsSchema, value)
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const ImagePush = [
+export const imagePush = [
 	validator("param", (value) => {
 		return v
 			.parseAsync(imagePushCommandParamsSchema, value)
@@ -496,7 +496,7 @@ export const ImagePush = [
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const ImageTag = [
+export const imageTag = [
 	validator("param", (value) => {
 		return v
 			.parseAsync(imageTagCommandParamsSchema, value)
@@ -508,7 +508,7 @@ export const ImageTag = [
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const ImageDelete = [
+export const imageDelete = [
 	validator("param", (value) => {
 		return v
 			.parseAsync(imageDeleteCommandParamsSchema, value)
@@ -520,32 +520,32 @@ export const ImageDelete = [
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const ImageSearch = [
+export const imageSearch = [
 	validator("query", (value) => {
 		return v
 			.parseAsync(imageSearchCommandQuerySchema, value)
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const ImagePrune = [
+export const imagePrune = [
 	validator("query", (value) => {
 		return v
 			.parseAsync(imagePruneCommandQuerySchema, value)
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const SystemAuth = [
+export const systemAuth = [
 	validator("json", (value) => {
 		return v
 			.parseAsync(systemAuthCommandBodySchema, value)
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const SystemInfo = [] as const;
-export const SystemVersion = [] as const;
-export const SystemPing = [] as const;
-export const SystemPingHead = [] as const;
-export const ImageCommit = [
+export const systemInfo = [] as const;
+export const systemVersion = [] as const;
+export const systemPing = [] as const;
+export const systemPingHead = [] as const;
+export const imageCommit = [
 	validator("json", (value) => {
 		return v
 			.parseAsync(imageCommitCommandBodySchema, value)
@@ -557,42 +557,42 @@ export const ImageCommit = [
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const SystemEvents = [
+export const systemEvents = [
 	validator("query", (value) => {
 		return v
 			.parseAsync(systemEventsCommandQuerySchema, value)
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const SystemDataUsage = [
+export const systemDataUsage = [
 	validator("query", (value) => {
 		return v
 			.parseAsync(systemDataUsageCommandQuerySchema, value)
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const ImageGet = [
+export const imageGet = [
 	validator("param", (value) => {
 		return v
 			.parseAsync(imageGetCommandParamsSchema, value)
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const ImageGetAll = [
+export const imageGetAll = [
 	validator("query", (value) => {
 		return v
 			.parseAsync(imageGetAllCommandQuerySchema, value)
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const ImageLoad = [
+export const imageLoad = [
 	validator("query", (value) => {
 		return v
 			.parseAsync(imageLoadCommandQuerySchema, value)
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const ContainerExec = [
+export const containerExec = [
 	validator("json", (value) => {
 		return v
 			.parseAsync(containerExecCommandBodySchema, value)
@@ -604,7 +604,7 @@ export const ContainerExec = [
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const ExecStart = [
+export const execStart = [
 	validator("json", (value) => {
 		return v
 			.parseAsync(execStartCommandBodySchema, value)
@@ -616,7 +616,7 @@ export const ExecStart = [
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const ExecResize = [
+export const execResize = [
 	validator("param", (value) => {
 		return v
 			.parseAsync(execResizeCommandParamsSchema, value)
@@ -628,35 +628,35 @@ export const ExecResize = [
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const ExecInspect = [
+export const execInspect = [
 	validator("param", (value) => {
 		return v
 			.parseAsync(execInspectCommandParamsSchema, value)
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const VolumeList = [
+export const volumeList = [
 	validator("query", (value) => {
 		return v
 			.parseAsync(volumeListCommandQuerySchema, value)
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const VolumeCreate = [
+export const volumeCreate = [
 	validator("json", (value) => {
 		return v
 			.parseAsync(volumeCreateCommandBodySchema, value)
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const VolumeInspect = [
+export const volumeInspect = [
 	validator("param", (value) => {
 		return v
 			.parseAsync(volumeInspectCommandParamsSchema, value)
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const VolumeUpdate = [
+export const volumeUpdate = [
 	validator("json", (value) => {
 		return v
 			.parseAsync(volumeUpdateCommandBodySchema, value)
@@ -673,7 +673,7 @@ export const VolumeUpdate = [
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const VolumeDelete = [
+export const volumeDelete = [
 	validator("param", (value) => {
 		return v
 			.parseAsync(volumeDeleteCommandParamsSchema, value)
@@ -685,21 +685,21 @@ export const VolumeDelete = [
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const VolumePrune = [
+export const volumePrune = [
 	validator("query", (value) => {
 		return v
 			.parseAsync(volumePruneCommandQuerySchema, value)
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const NetworkList = [
+export const networkList = [
 	validator("query", (value) => {
 		return v
 			.parseAsync(networkListCommandQuerySchema, value)
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const NetworkInspect = [
+export const networkInspect = [
 	validator("param", (value) => {
 		return v
 			.parseAsync(networkInspectCommandParamsSchema, value)
@@ -711,21 +711,21 @@ export const NetworkInspect = [
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const NetworkDelete = [
+export const networkDelete = [
 	validator("param", (value) => {
 		return v
 			.parseAsync(networkDeleteCommandParamsSchema, value)
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const NetworkCreate = [
+export const networkCreate = [
 	validator("json", (value) => {
 		return v
 			.parseAsync(networkCreateCommandBodySchema, value)
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const NetworkConnect = [
+export const networkConnect = [
 	validator("json", (value) => {
 		return v
 			.parseAsync(networkConnectCommandBodySchema, value)
@@ -737,7 +737,7 @@ export const NetworkConnect = [
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const NetworkDisconnect = [
+export const networkDisconnect = [
 	validator("json", (value) => {
 		return v
 			.parseAsync(networkDisconnectCommandBodySchema, value)
@@ -749,28 +749,28 @@ export const NetworkDisconnect = [
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const NetworkPrune = [
+export const networkPrune = [
 	validator("query", (value) => {
 		return v
 			.parseAsync(networkPruneCommandQuerySchema, value)
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const PluginList = [
+export const pluginList = [
 	validator("query", (value) => {
 		return v
 			.parseAsync(pluginListCommandQuerySchema, value)
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const GetPluginPrivileges = [
+export const getPluginPrivileges = [
 	validator("query", (value) => {
 		return v
 			.parseAsync(getPluginPrivilegesCommandQuerySchema, value)
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const PluginPull = [
+export const pluginPull = [
 	validator("json", (value) => {
 		return v
 			.parseAsync(pluginPullCommandBodySchema, value)
@@ -782,14 +782,14 @@ export const PluginPull = [
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const PluginInspect = [
+export const pluginInspect = [
 	validator("param", (value) => {
 		return v
 			.parseAsync(pluginInspectCommandParamsSchema, value)
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const PluginDelete = [
+export const pluginDelete = [
 	validator("param", (value) => {
 		return v
 			.parseAsync(pluginDeleteCommandParamsSchema, value)
@@ -801,7 +801,7 @@ export const PluginDelete = [
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const PluginEnable = [
+export const pluginEnable = [
 	validator("param", (value) => {
 		return v
 			.parseAsync(pluginEnableCommandParamsSchema, value)
@@ -813,7 +813,7 @@ export const PluginEnable = [
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const PluginDisable = [
+export const pluginDisable = [
 	validator("param", (value) => {
 		return v
 			.parseAsync(pluginDisableCommandParamsSchema, value)
@@ -825,7 +825,7 @@ export const PluginDisable = [
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const PluginUpgrade = [
+export const pluginUpgrade = [
 	validator("json", (value) => {
 		return v
 			.parseAsync(pluginUpgradeCommandBodySchema, value)
@@ -842,21 +842,21 @@ export const PluginUpgrade = [
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const PluginCreate = [
+export const pluginCreate = [
 	validator("query", (value) => {
 		return v
 			.parseAsync(pluginCreateCommandQuerySchema, value)
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const PluginPush = [
+export const pluginPush = [
 	validator("param", (value) => {
 		return v
 			.parseAsync(pluginPushCommandParamsSchema, value)
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const PluginSet = [
+export const pluginSet = [
 	validator("json", (value) => {
 		return v
 			.parseAsync(pluginSetCommandBodySchema, value)
@@ -868,21 +868,21 @@ export const PluginSet = [
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const NodeList = [
+export const nodeList = [
 	validator("query", (value) => {
 		return v
 			.parseAsync(nodeListCommandQuerySchema, value)
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const NodeInspect = [
+export const nodeInspect = [
 	validator("param", (value) => {
 		return v
 			.parseAsync(nodeInspectCommandParamsSchema, value)
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const NodeDelete = [
+export const nodeDelete = [
 	validator("param", (value) => {
 		return v
 			.parseAsync(nodeDeleteCommandParamsSchema, value)
@@ -894,7 +894,7 @@ export const NodeDelete = [
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const NodeUpdate = [
+export const nodeUpdate = [
 	validator("json", (value) => {
 		return v
 			.parseAsync(nodeUpdateCommandBodySchema, value)
@@ -911,29 +911,29 @@ export const NodeUpdate = [
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const SwarmInspect = [] as const;
-export const SwarmInit = [
+export const swarmInspect = [] as const;
+export const swarmInit = [
 	validator("json", (value) => {
 		return v
 			.parseAsync(swarmInitCommandBodySchema, value)
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const SwarmJoin = [
+export const swarmJoin = [
 	validator("json", (value) => {
 		return v
 			.parseAsync(swarmJoinCommandBodySchema, value)
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const SwarmLeave = [
+export const swarmLeave = [
 	validator("query", (value) => {
 		return v
 			.parseAsync(swarmLeaveCommandQuerySchema, value)
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const SwarmUpdate = [
+export const swarmUpdate = [
 	validator("json", (value) => {
 		return v
 			.parseAsync(swarmUpdateCommandBodySchema, value)
@@ -945,29 +945,29 @@ export const SwarmUpdate = [
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const SwarmUnlockkey = [] as const;
-export const SwarmUnlock = [
+export const swarmUnlockkey = [] as const;
+export const swarmUnlock = [
 	validator("json", (value) => {
 		return v
 			.parseAsync(swarmUnlockCommandBodySchema, value)
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const ServiceList = [
+export const serviceList = [
 	validator("query", (value) => {
 		return v
 			.parseAsync(serviceListCommandQuerySchema, value)
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const ServiceCreate = [
+export const serviceCreate = [
 	validator("json", (value) => {
 		return v
 			.parseAsync(serviceCreateCommandBodySchema, value)
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const ServiceInspect = [
+export const serviceInspect = [
 	validator("param", (value) => {
 		return v
 			.parseAsync(serviceInspectCommandParamsSchema, value)
@@ -979,14 +979,14 @@ export const ServiceInspect = [
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const ServiceDelete = [
+export const serviceDelete = [
 	validator("param", (value) => {
 		return v
 			.parseAsync(serviceDeleteCommandParamsSchema, value)
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const ServiceUpdate = [
+export const serviceUpdate = [
 	validator("json", (value) => {
 		return v
 			.parseAsync(serviceUpdateCommandBodySchema, value)
@@ -1003,7 +1003,7 @@ export const ServiceUpdate = [
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const ServiceLogs = [
+export const serviceLogs = [
 	validator("param", (value) => {
 		return v
 			.parseAsync(serviceLogsCommandParamsSchema, value)
@@ -1015,21 +1015,21 @@ export const ServiceLogs = [
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const TaskList = [
+export const taskList = [
 	validator("query", (value) => {
 		return v
 			.parseAsync(taskListCommandQuerySchema, value)
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const TaskInspect = [
+export const taskInspect = [
 	validator("param", (value) => {
 		return v
 			.parseAsync(taskInspectCommandParamsSchema, value)
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const TaskLogs = [
+export const taskLogs = [
 	validator("param", (value) => {
 		return v
 			.parseAsync(taskLogsCommandParamsSchema, value)
@@ -1041,35 +1041,35 @@ export const TaskLogs = [
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const SecretList = [
+export const secretList = [
 	validator("query", (value) => {
 		return v
 			.parseAsync(secretListCommandQuerySchema, value)
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const SecretCreate = [
+export const secretCreate = [
 	validator("json", (value) => {
 		return v
 			.parseAsync(secretCreateCommandBodySchema, value)
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const SecretInspect = [
+export const secretInspect = [
 	validator("param", (value) => {
 		return v
 			.parseAsync(secretInspectCommandParamsSchema, value)
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const SecretDelete = [
+export const secretDelete = [
 	validator("param", (value) => {
 		return v
 			.parseAsync(secretDeleteCommandParamsSchema, value)
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const SecretUpdate = [
+export const secretUpdate = [
 	validator("json", (value) => {
 		return v
 			.parseAsync(secretUpdateCommandBodySchema, value)
@@ -1086,35 +1086,35 @@ export const SecretUpdate = [
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const ConfigList = [
+export const configList = [
 	validator("query", (value) => {
 		return v
 			.parseAsync(configListCommandQuerySchema, value)
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const ConfigCreate = [
+export const configCreate = [
 	validator("json", (value) => {
 		return v
 			.parseAsync(configCreateCommandBodySchema, value)
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const ConfigInspect = [
+export const configInspect = [
 	validator("param", (value) => {
 		return v
 			.parseAsync(configInspectCommandParamsSchema, value)
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const ConfigDelete = [
+export const configDelete = [
 	validator("param", (value) => {
 		return v
 			.parseAsync(configDeleteCommandParamsSchema, value)
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const ConfigUpdate = [
+export const configUpdate = [
 	validator("json", (value) => {
 		return v
 			.parseAsync(configUpdateCommandBodySchema, value)
@@ -1131,11 +1131,11 @@ export const ConfigUpdate = [
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const DistributionInspect = [
+export const distributionInspect = [
 	validator("param", (value) => {
 		return v
 			.parseAsync(distributionInspectCommandParamsSchema, value)
 			.catch(toPublicValibotHonoError);
 	}),
 ] as const;
-export const Session = [] as const;
+export const session = [] as const;

--- a/__tests__/fixtures/docker/main.ts
+++ b/__tests__/fixtures/docker/main.ts
@@ -3,7 +3,7 @@
  *
  * WARN: Do not edit directly.
  *
- * Generated on 2026-03-06T07:45:59.608Z
+ * Generated on 2026-03-17T13:16:20.373Z
  *
  */
 import {

--- a/__tests__/fixtures/docker/types.ts
+++ b/__tests__/fixtures/docker/types.ts
@@ -3,7 +3,7 @@
  *
  * WARN: Do not edit directly.
  *
- * Generated on 2026-03-06T07:45:59.608Z
+ * Generated on 2026-03-17T13:16:20.373Z
  *
  */
 import type { Jsonifiable } from "type-fest";

--- a/__tests__/fixtures/docker/valibot.ts
+++ b/__tests__/fixtures/docker/valibot.ts
@@ -3,7 +3,7 @@
  *
  * WARN: Do not edit directly.
  *
- * Generated on 2026-03-06T07:45:59.608Z
+ * Generated on 2026-03-17T13:16:20.373Z
  *
  */
 import * as v from "valibot";

--- a/__tests__/fixtures/openai/commands.ts
+++ b/__tests__/fixtures/openai/commands.ts
@@ -3,7 +3,7 @@
  *
  * WARN: Do not edit directly.
  *
- * Generated on 2026-03-06T07:45:26.343Z
+ * Generated on 2026-03-17T13:15:43.170Z
  *
  */
 /** eslint-disable max-classes */
@@ -185,6 +185,17 @@ import type {
 	VectorStoreFileObject,
 	VectorStoreObject,
 } from "./types.js";
+
+/**
+ * Tagged template literal that applies encodeURIComponent to all interpolated values, protecting path integrity from characters like `/` and `#`.
+ * @example encodePath`/users/${userId}` // "/users/foo%2Fbar"
+ */
+function encodePath(
+	strings: TemplateStringsArray,
+	...values: string[]
+): string {
+	return String.raw({ raw: strings }, ...values.map(encodeURIComponent));
+}
 
 /**
  * CreateChatCompletionCommand
@@ -405,7 +416,7 @@ export class DeleteFileCommand extends Command<
 
 	constructor(input: DeleteFileCommandInput) {
 		const { file_id } = input;
-		super(`/files/${file_id}`);
+		super(encodePath`/files/${file_id}`);
 	}
 }
 
@@ -422,7 +433,7 @@ export class RetrieveFileCommand extends Command<
 
 	constructor(input: RetrieveFileCommandInput) {
 		const { file_id } = input;
-		super(`/files/${file_id}`);
+		super(encodePath`/files/${file_id}`);
 	}
 }
 
@@ -439,7 +450,7 @@ export class DownloadFileCommand extends Command<
 
 	constructor(input: DownloadFileCommandInput) {
 		const { file_id } = input;
-		super(`/files/${file_id}/content`);
+		super(encodePath`/files/${file_id}/content`);
 	}
 }
 
@@ -498,7 +509,7 @@ export class AddUploadPartCommand extends Command<
 
 	constructor(input: AddUploadPartCommandInput) {
 		const { upload_id, body } = input;
-		super(`/uploads/${upload_id}/parts`, body);
+		super(encodePath`/uploads/${upload_id}/parts`, body);
 	}
 }
 
@@ -526,7 +537,7 @@ export class CompleteUploadCommand extends Command<
 
 	constructor(input: CompleteUploadCommandInput) {
 		const { upload_id, ...body } = input;
-		super(`/uploads/${upload_id}/complete`, jsonStringify(body));
+		super(encodePath`/uploads/${upload_id}/complete`, jsonStringify(body));
 	}
 }
 
@@ -543,7 +554,7 @@ export class CancelUploadCommand extends Command<
 
 	constructor(input: CancelUploadCommandInput) {
 		const { upload_id } = input;
-		super(`/uploads/${upload_id}/cancel`);
+		super(encodePath`/uploads/${upload_id}/cancel`);
 	}
 }
 
@@ -603,7 +614,7 @@ export class RetrieveFineTuningJobCommand extends Command<
 
 	constructor(input: RetrieveFineTuningJobCommandInput) {
 		const { fine_tuning_job_id } = input;
-		super(`/fine_tuning/jobs/${fine_tuning_job_id}`);
+		super(encodePath`/fine_tuning/jobs/${fine_tuning_job_id}`);
 	}
 }
 
@@ -622,7 +633,7 @@ export class ListFineTuningEventsCommand extends Command<
 	constructor(input: ListFineTuningEventsCommandInput) {
 		const { fine_tuning_job_id, after, limit } = input;
 		super(
-			`/fine_tuning/jobs/${fine_tuning_job_id}/events`,
+			encodePath`/fine_tuning/jobs/${fine_tuning_job_id}/events`,
 			undefined,
 			stripUndefined({ after, limit }),
 		);
@@ -642,7 +653,7 @@ export class CancelFineTuningJobCommand extends Command<
 
 	constructor(input: CancelFineTuningJobCommandInput) {
 		const { fine_tuning_job_id } = input;
-		super(`/fine_tuning/jobs/${fine_tuning_job_id}/cancel`);
+		super(encodePath`/fine_tuning/jobs/${fine_tuning_job_id}/cancel`);
 	}
 }
 
@@ -661,7 +672,7 @@ export class ListFineTuningJobCheckpointsCommand extends Command<
 	constructor(input: ListFineTuningJobCheckpointsCommandInput) {
 		const { fine_tuning_job_id, after, limit } = input;
 		super(
-			`/fine_tuning/jobs/${fine_tuning_job_id}/checkpoints`,
+			encodePath`/fine_tuning/jobs/${fine_tuning_job_id}/checkpoints`,
 			undefined,
 			stripUndefined({ after, limit }),
 		);
@@ -695,7 +706,7 @@ export class RetrieveModelCommand extends Command<
 
 	constructor(input: RetrieveModelCommandInput) {
 		const { model } = input;
-		super(`/models/${model}`);
+		super(encodePath`/models/${model}`);
 	}
 }
 
@@ -713,7 +724,7 @@ export class DeleteModelCommand extends Command<
 
 	constructor(input: DeleteModelCommandInput) {
 		const { model } = input;
-		super(`/models/${model}`);
+		super(encodePath`/models/${model}`);
 	}
 }
 
@@ -787,7 +798,7 @@ export class GetAssistantCommand extends Command<
 
 	constructor(input: GetAssistantCommandInput) {
 		const { assistant_id } = input;
-		super(`/assistants/${assistant_id}`);
+		super(encodePath`/assistants/${assistant_id}`);
 	}
 }
 
@@ -804,7 +815,7 @@ export class ModifyAssistantCommand extends Command<
 
 	constructor(input: ModifyAssistantCommandInput) {
 		const { assistant_id, ...body } = input;
-		super(`/assistants/${assistant_id}`, jsonStringify(body));
+		super(encodePath`/assistants/${assistant_id}`, jsonStringify(body));
 	}
 }
 
@@ -821,7 +832,7 @@ export class DeleteAssistantCommand extends Command<
 
 	constructor(input: DeleteAssistantCommandInput) {
 		const { assistant_id } = input;
-		super(`/assistants/${assistant_id}`);
+		super(encodePath`/assistants/${assistant_id}`);
 	}
 }
 
@@ -855,7 +866,7 @@ export class GetThreadCommand extends Command<
 
 	constructor(input: GetThreadCommandInput) {
 		const { thread_id } = input;
-		super(`/threads/${thread_id}`);
+		super(encodePath`/threads/${thread_id}`);
 	}
 }
 
@@ -872,7 +883,7 @@ export class ModifyThreadCommand extends Command<
 
 	constructor(input: ModifyThreadCommandInput) {
 		const { thread_id, ...body } = input;
-		super(`/threads/${thread_id}`, jsonStringify(body));
+		super(encodePath`/threads/${thread_id}`, jsonStringify(body));
 	}
 }
 
@@ -889,7 +900,7 @@ export class DeleteThreadCommand extends Command<
 
 	constructor(input: DeleteThreadCommandInput) {
 		const { thread_id } = input;
-		super(`/threads/${thread_id}`);
+		super(encodePath`/threads/${thread_id}`);
 	}
 }
 
@@ -908,7 +919,7 @@ export class ListMessagesCommand extends Command<
 	constructor(input: ListMessagesCommandInput) {
 		const { thread_id, limit, order, after, before, run_id } = input;
 		super(
-			`/threads/${thread_id}/messages`,
+			encodePath`/threads/${thread_id}/messages`,
 			undefined,
 			stripUndefined({ limit, order, after, before, run_id }),
 		);
@@ -928,7 +939,7 @@ export class CreateMessageCommand extends Command<
 
 	constructor(input: CreateMessageCommandInput) {
 		const { thread_id, ...body } = input;
-		super(`/threads/${thread_id}/messages`, jsonStringify(body));
+		super(encodePath`/threads/${thread_id}/messages`, jsonStringify(body));
 	}
 }
 
@@ -945,7 +956,7 @@ export class GetMessageCommand extends Command<
 
 	constructor(input: GetMessageCommandInput) {
 		const { thread_id, message_id } = input;
-		super(`/threads/${thread_id}/messages/${message_id}`);
+		super(encodePath`/threads/${thread_id}/messages/${message_id}`);
 	}
 }
 
@@ -962,7 +973,10 @@ export class ModifyMessageCommand extends Command<
 
 	constructor(input: ModifyMessageCommandInput) {
 		const { thread_id, message_id, ...body } = input;
-		super(`/threads/${thread_id}/messages/${message_id}`, jsonStringify(body));
+		super(
+			encodePath`/threads/${thread_id}/messages/${message_id}`,
+			jsonStringify(body),
+		);
 	}
 }
 
@@ -979,7 +993,7 @@ export class DeleteMessageCommand extends Command<
 
 	constructor(input: DeleteMessageCommandInput) {
 		const { thread_id, message_id } = input;
-		super(`/threads/${thread_id}/messages/${message_id}`);
+		super(encodePath`/threads/${thread_id}/messages/${message_id}`);
 	}
 }
 
@@ -1015,7 +1029,7 @@ export class ListRunsCommand extends Command<
 	constructor(input: ListRunsCommandInput) {
 		const { thread_id, limit, order, after, before } = input;
 		super(
-			`/threads/${thread_id}/runs`,
+			encodePath`/threads/${thread_id}/runs`,
 			undefined,
 			stripUndefined({ limit, order, after, before }),
 		);
@@ -1037,7 +1051,7 @@ export class CreateRunCommand extends Command<
 	constructor(input: CreateRunCommandInput) {
 		const { thread_id, include, ...body } = input;
 		super(
-			`/threads/${thread_id}/runs`,
+			encodePath`/threads/${thread_id}/runs`,
 			jsonStringify(body),
 			stripUndefined({ include }),
 		);
@@ -1054,7 +1068,7 @@ export class GetRunCommand extends Command<GetRunCommandInput, RunObject> {
 
 	constructor(input: GetRunCommandInput) {
 		const { thread_id, run_id } = input;
-		super(`/threads/${thread_id}/runs/${run_id}`);
+		super(encodePath`/threads/${thread_id}/runs/${run_id}`);
 	}
 }
 
@@ -1071,7 +1085,10 @@ export class ModifyRunCommand extends Command<
 
 	constructor(input: ModifyRunCommandInput) {
 		const { thread_id, run_id, ...body } = input;
-		super(`/threads/${thread_id}/runs/${run_id}`, jsonStringify(body));
+		super(
+			encodePath`/threads/${thread_id}/runs/${run_id}`,
+			jsonStringify(body),
+		);
 	}
 }
 
@@ -1092,7 +1109,7 @@ export class SubmitToolOuputsToRunCommand extends Command<
 	constructor(input: SubmitToolOuputsToRunCommandInput) {
 		const { thread_id, run_id, ...body } = input;
 		super(
-			`/threads/${thread_id}/runs/${run_id}/submit_tool_outputs`,
+			encodePath`/threads/${thread_id}/runs/${run_id}/submit_tool_outputs`,
 			jsonStringify(body),
 		);
 	}
@@ -1111,7 +1128,7 @@ export class CancelRunCommand extends Command<
 
 	constructor(input: CancelRunCommandInput) {
 		const { thread_id, run_id } = input;
-		super(`/threads/${thread_id}/runs/${run_id}/cancel`);
+		super(encodePath`/threads/${thread_id}/runs/${run_id}/cancel`);
 	}
 }
 
@@ -1130,7 +1147,7 @@ export class ListRunStepsCommand extends Command<
 	constructor(input: ListRunStepsCommandInput) {
 		const { thread_id, run_id, limit, order, after, before, include } = input;
 		super(
-			`/threads/${thread_id}/runs/${run_id}/steps`,
+			encodePath`/threads/${thread_id}/runs/${run_id}/steps`,
 			undefined,
 			stripUndefined({ limit, order, after, before, include }),
 		);
@@ -1152,7 +1169,7 @@ export class GetRunStepCommand extends Command<
 	constructor(input: GetRunStepCommandInput) {
 		const { thread_id, run_id, step_id, include } = input;
 		super(
-			`/threads/${thread_id}/runs/${run_id}/steps/${step_id}`,
+			encodePath`/threads/${thread_id}/runs/${run_id}/steps/${step_id}`,
 			undefined,
 			stripUndefined({ include }),
 		);
@@ -1211,7 +1228,7 @@ export class GetVectorStoreCommand extends Command<
 
 	constructor(input: GetVectorStoreCommandInput) {
 		const { vector_store_id } = input;
-		super(`/vector_stores/${vector_store_id}`);
+		super(encodePath`/vector_stores/${vector_store_id}`);
 	}
 }
 
@@ -1228,7 +1245,7 @@ export class ModifyVectorStoreCommand extends Command<
 
 	constructor(input: ModifyVectorStoreCommandInput) {
 		const { vector_store_id, ...body } = input;
-		super(`/vector_stores/${vector_store_id}`, jsonStringify(body));
+		super(encodePath`/vector_stores/${vector_store_id}`, jsonStringify(body));
 	}
 }
 
@@ -1245,7 +1262,7 @@ export class DeleteVectorStoreCommand extends Command<
 
 	constructor(input: DeleteVectorStoreCommandInput) {
 		const { vector_store_id } = input;
-		super(`/vector_stores/${vector_store_id}`);
+		super(encodePath`/vector_stores/${vector_store_id}`);
 	}
 }
 
@@ -1264,7 +1281,7 @@ export class ListVectorStoreFilesCommand extends Command<
 	constructor(input: ListVectorStoreFilesCommandInput) {
 		const { vector_store_id, limit, order, after, before, filter } = input;
 		super(
-			`/vector_stores/${vector_store_id}/files`,
+			encodePath`/vector_stores/${vector_store_id}/files`,
 			undefined,
 			stripUndefined({ limit, order, after, before, filter }),
 		);
@@ -1285,7 +1302,10 @@ export class CreateVectorStoreFileCommand extends Command<
 
 	constructor(input: CreateVectorStoreFileCommandInput) {
 		const { vector_store_id, ...body } = input;
-		super(`/vector_stores/${vector_store_id}/files`, jsonStringify(body));
+		super(
+			encodePath`/vector_stores/${vector_store_id}/files`,
+			jsonStringify(body),
+		);
 	}
 }
 
@@ -1302,7 +1322,7 @@ export class GetVectorStoreFileCommand extends Command<
 
 	constructor(input: GetVectorStoreFileCommandInput) {
 		const { vector_store_id, file_id } = input;
-		super(`/vector_stores/${vector_store_id}/files/${file_id}`);
+		super(encodePath`/vector_stores/${vector_store_id}/files/${file_id}`);
 	}
 }
 
@@ -1321,7 +1341,7 @@ export class DeleteVectorStoreFileCommand extends Command<
 
 	constructor(input: DeleteVectorStoreFileCommandInput) {
 		const { vector_store_id, file_id } = input;
-		super(`/vector_stores/${vector_store_id}/files/${file_id}`);
+		super(encodePath`/vector_stores/${vector_store_id}/files/${file_id}`);
 	}
 }
 
@@ -1339,7 +1359,7 @@ export class CreateVectorStoreFileBatchCommand extends Command<
 	constructor(input: CreateVectorStoreFileBatchCommandInput) {
 		const { vector_store_id, ...body } = input;
 		super(
-			`/vector_stores/${vector_store_id}/file_batches`,
+			encodePath`/vector_stores/${vector_store_id}/file_batches`,
 			jsonStringify(body),
 		);
 	}
@@ -1358,7 +1378,9 @@ export class GetVectorStoreFileBatchCommand extends Command<
 
 	constructor(input: GetVectorStoreFileBatchCommandInput) {
 		const { vector_store_id, batch_id } = input;
-		super(`/vector_stores/${vector_store_id}/file_batches/${batch_id}`);
+		super(
+			encodePath`/vector_stores/${vector_store_id}/file_batches/${batch_id}`,
+		);
 	}
 }
 
@@ -1376,7 +1398,9 @@ export class CancelVectorStoreFileBatchCommand extends Command<
 
 	constructor(input: CancelVectorStoreFileBatchCommandInput) {
 		const { vector_store_id, batch_id } = input;
-		super(`/vector_stores/${vector_store_id}/file_batches/${batch_id}/cancel`);
+		super(
+			encodePath`/vector_stores/${vector_store_id}/file_batches/${batch_id}/cancel`,
+		);
 	}
 }
 
@@ -1396,7 +1420,7 @@ export class ListFilesInVectorStoreBatchCommand extends Command<
 		const { vector_store_id, batch_id, limit, order, after, before, filter } =
 			input;
 		super(
-			`/vector_stores/${vector_store_id}/file_batches/${batch_id}/files`,
+			encodePath`/vector_stores/${vector_store_id}/file_batches/${batch_id}/files`,
 			undefined,
 			stripUndefined({ limit, order, after, before, filter }),
 		);
@@ -1451,7 +1475,7 @@ export class RetrieveBatchCommand extends Command<
 
 	constructor(input: RetrieveBatchCommandInput) {
 		const { batch_id } = input;
-		super(`/batches/${batch_id}`);
+		super(encodePath`/batches/${batch_id}`);
 	}
 }
 
@@ -1470,7 +1494,7 @@ export class CancelBatchCommand extends Command<
 
 	constructor(input: CancelBatchCommandInput) {
 		const { batch_id } = input;
-		super(`/batches/${batch_id}/cancel`);
+		super(encodePath`/batches/${batch_id}/cancel`);
 	}
 }
 
@@ -1562,7 +1586,7 @@ export class RetrieveInviteCommand extends Command<
 
 	constructor(input: RetrieveInviteCommandInput) {
 		const { invite_id } = input;
-		super(`/organization/invites/${invite_id}`);
+		super(encodePath`/organization/invites/${invite_id}`);
 	}
 }
 
@@ -1580,7 +1604,7 @@ export class DeleteInviteCommand extends Command<
 
 	constructor(input: DeleteInviteCommandInput) {
 		const { invite_id } = input;
-		super(`/organization/invites/${invite_id}`);
+		super(encodePath`/organization/invites/${invite_id}`);
 	}
 }
 
@@ -1615,7 +1639,7 @@ export class RetrieveUserCommand extends Command<
 
 	constructor(input: RetrieveUserCommandInput) {
 		const { user_id } = input;
-		super(`/organization/users/${user_id}`);
+		super(encodePath`/organization/users/${user_id}`);
 	}
 }
 
@@ -1629,7 +1653,7 @@ export class ModifyUserCommand extends Command<ModifyUserCommandInput, User> {
 
 	constructor(input: ModifyUserCommandInput) {
 		const { user_id, ...body } = input;
-		super(`/organization/users/${user_id}`, jsonStringify(body));
+		super(encodePath`/organization/users/${user_id}`, jsonStringify(body));
 	}
 }
 
@@ -1646,7 +1670,7 @@ export class DeleteUserCommand extends Command<
 
 	constructor(input: DeleteUserCommandInput) {
 		const { user_id } = input;
-		super(`/organization/users/${user_id}`);
+		super(encodePath`/organization/users/${user_id}`);
 	}
 }
 
@@ -1703,7 +1727,7 @@ export class RetrieveProjectCommand extends Command<
 
 	constructor(input: RetrieveProjectCommandInput) {
 		const { project_id } = input;
-		super(`/organization/projects/${project_id}`);
+		super(encodePath`/organization/projects/${project_id}`);
 	}
 }
 
@@ -1720,7 +1744,10 @@ export class ModifyProjectCommand extends Command<
 
 	constructor(input: ModifyProjectCommandInput) {
 		const { project_id, ...body } = input;
-		super(`/organization/projects/${project_id}`, jsonStringify(body));
+		super(
+			encodePath`/organization/projects/${project_id}`,
+			jsonStringify(body),
+		);
 	}
 }
 
@@ -1738,7 +1765,7 @@ export class ArchiveProjectCommand extends Command<
 
 	constructor(input: ArchiveProjectCommandInput) {
 		const { project_id } = input;
-		super(`/organization/projects/${project_id}/archive`);
+		super(encodePath`/organization/projects/${project_id}/archive`);
 	}
 }
 
@@ -1757,7 +1784,7 @@ export class ListProjectUsersCommand extends Command<
 	constructor(input: ListProjectUsersCommandInput) {
 		const { project_id, limit, after } = input;
 		super(
-			`/organization/projects/${project_id}/users`,
+			encodePath`/organization/projects/${project_id}/users`,
 			undefined,
 			stripUndefined({ limit, after }),
 		);
@@ -1778,7 +1805,10 @@ export class CreateProjectUserCommand extends Command<
 
 	constructor(input: CreateProjectUserCommandInput) {
 		const { project_id, ...body } = input;
-		super(`/organization/projects/${project_id}/users`, jsonStringify(body));
+		super(
+			encodePath`/organization/projects/${project_id}/users`,
+			jsonStringify(body),
+		);
 	}
 }
 
@@ -1795,7 +1825,7 @@ export class RetrieveProjectUserCommand extends Command<
 
 	constructor(input: RetrieveProjectUserCommandInput) {
 		const { project_id, user_id } = input;
-		super(`/organization/projects/${project_id}/users/${user_id}`);
+		super(encodePath`/organization/projects/${project_id}/users/${user_id}`);
 	}
 }
 
@@ -1813,7 +1843,7 @@ export class ModifyProjectUserCommand extends Command<
 	constructor(input: ModifyProjectUserCommandInput) {
 		const { project_id, user_id, ...body } = input;
 		super(
-			`/organization/projects/${project_id}/users/${user_id}`,
+			encodePath`/organization/projects/${project_id}/users/${user_id}`,
 			jsonStringify(body),
 		);
 	}
@@ -1832,7 +1862,7 @@ export class DeleteProjectUserCommand extends Command<
 
 	constructor(input: DeleteProjectUserCommandInput) {
 		const { project_id, user_id } = input;
-		super(`/organization/projects/${project_id}/users/${user_id}`);
+		super(encodePath`/organization/projects/${project_id}/users/${user_id}`);
 	}
 }
 
@@ -1851,7 +1881,7 @@ export class ListProjectServiceAccountsCommand extends Command<
 	constructor(input: ListProjectServiceAccountsCommandInput) {
 		const { project_id, limit, after } = input;
 		super(
-			`/organization/projects/${project_id}/service_accounts`,
+			encodePath`/organization/projects/${project_id}/service_accounts`,
 			undefined,
 			stripUndefined({ limit, after }),
 		);
@@ -1873,7 +1903,7 @@ export class CreateProjectServiceAccountCommand extends Command<
 	constructor(input: CreateProjectServiceAccountCommandInput) {
 		const { project_id, ...body } = input;
 		super(
-			`/organization/projects/${project_id}/service_accounts`,
+			encodePath`/organization/projects/${project_id}/service_accounts`,
 			jsonStringify(body),
 		);
 	}
@@ -1893,7 +1923,7 @@ export class RetrieveProjectServiceAccountCommand extends Command<
 	constructor(input: RetrieveProjectServiceAccountCommandInput) {
 		const { project_id, service_account_id } = input;
 		super(
-			`/organization/projects/${project_id}/service_accounts/${service_account_id}`,
+			encodePath`/organization/projects/${project_id}/service_accounts/${service_account_id}`,
 		);
 	}
 }
@@ -1912,7 +1942,7 @@ export class DeleteProjectServiceAccountCommand extends Command<
 	constructor(input: DeleteProjectServiceAccountCommandInput) {
 		const { project_id, service_account_id } = input;
 		super(
-			`/organization/projects/${project_id}/service_accounts/${service_account_id}`,
+			encodePath`/organization/projects/${project_id}/service_accounts/${service_account_id}`,
 		);
 	}
 }
@@ -1932,7 +1962,7 @@ export class ListProjectApiKeysCommand extends Command<
 	constructor(input: ListProjectApiKeysCommandInput) {
 		const { project_id, limit, after } = input;
 		super(
-			`/organization/projects/${project_id}/api_keys`,
+			encodePath`/organization/projects/${project_id}/api_keys`,
 			undefined,
 			stripUndefined({ limit, after }),
 		);
@@ -1952,7 +1982,7 @@ export class RetrieveProjectApiKeyCommand extends Command<
 
 	constructor(input: RetrieveProjectApiKeyCommandInput) {
 		const { project_id, key_id } = input;
-		super(`/organization/projects/${project_id}/api_keys/${key_id}`);
+		super(encodePath`/organization/projects/${project_id}/api_keys/${key_id}`);
 	}
 }
 
@@ -1969,6 +1999,6 @@ export class DeleteProjectApiKeyCommand extends Command<
 
 	constructor(input: DeleteProjectApiKeyCommandInput) {
 		const { project_id, key_id } = input;
-		super(`/organization/projects/${project_id}/api_keys/${key_id}`);
+		super(encodePath`/organization/projects/${project_id}/api_keys/${key_id}`);
 	}
 }

--- a/__tests__/fixtures/openai/hono-valibot.ts
+++ b/__tests__/fixtures/openai/hono-valibot.ts
@@ -3,7 +3,7 @@
  *
  * WARN: Do not edit directly.
  *
- * Generated on 2026-03-06T07:45:26.343Z
+ * Generated on 2026-03-17T13:15:43.170Z
  *
  */
 

--- a/__tests__/fixtures/openai/main.ts
+++ b/__tests__/fixtures/openai/main.ts
@@ -3,7 +3,7 @@
  *
  * WARN: Do not edit directly.
  *
- * Generated on 2026-03-06T07:45:26.343Z
+ * Generated on 2026-03-17T13:15:43.170Z
  *
  */
 import {

--- a/__tests__/fixtures/openai/types.ts
+++ b/__tests__/fixtures/openai/types.ts
@@ -3,7 +3,7 @@
  *
  * WARN: Do not edit directly.
  *
- * Generated on 2026-03-06T07:45:26.343Z
+ * Generated on 2026-03-17T13:15:43.170Z
  *
  */
 import type { Jsonifiable } from "type-fest";

--- a/__tests__/fixtures/openai/valibot.ts
+++ b/__tests__/fixtures/openai/valibot.ts
@@ -3,7 +3,7 @@
  *
  * WARN: Do not edit directly.
  *
- * Generated on 2026-03-06T07:45:26.343Z
+ * Generated on 2026-03-17T13:15:43.170Z
  *
  */
 import * as v from "valibot";

--- a/__tests__/fixtures/petstore/commands.ts
+++ b/__tests__/fixtures/petstore/commands.ts
@@ -3,7 +3,7 @@
  *
  * WARN: Do not edit directly.
  *
- * Generated on 2026-03-06T07:45:20.003Z
+ * Generated on 2026-03-17T13:15:35.006Z
  *
  */
 /** eslint-disable max-classes */
@@ -16,6 +16,17 @@ import type {
 	FindPetsCommandQuery,
 	Pet,
 } from "./types.js";
+
+/**
+ * Tagged template literal that applies encodeURIComponent to all interpolated values, protecting path integrity from characters like `/` and `#`.
+ * @example encodePath`/users/${userId}` // "/users/foo%2Fbar"
+ */
+function encodePath(
+	strings: TemplateStringsArray,
+	...values: string[]
+): string {
+	return String.raw({ raw: strings }, ...values.map(encodeURIComponent));
+}
 
 /**
  * Returns all pets from the system that the user has access to
@@ -79,7 +90,7 @@ export class FindPetByIdCommand extends Command<FindPetByIdCommandInput, Pet> {
 
 	constructor(input: FindPetByIdCommandInput) {
 		const { id } = input;
-		super(`/pets/${id}`);
+		super(encodePath`/pets/${id}`);
 	}
 }
 
@@ -95,6 +106,6 @@ export class DeletePetCommand extends Command<
 
 	constructor(input: DeletePetCommandInput) {
 		const { id } = input;
-		super(`/pets/${id}`);
+		super(encodePath`/pets/${id}`);
 	}
 }

--- a/__tests__/fixtures/petstore/hono-valibot.ts
+++ b/__tests__/fixtures/petstore/hono-valibot.ts
@@ -3,7 +3,7 @@
  *
  * WARN: Do not edit directly.
  *
- * Generated on 2026-03-06T07:45:20.003Z
+ * Generated on 2026-03-17T13:15:35.006Z
  *
  */
 

--- a/__tests__/fixtures/petstore/main.ts
+++ b/__tests__/fixtures/petstore/main.ts
@@ -3,7 +3,7 @@
  *
  * WARN: Do not edit directly.
  *
- * Generated on 2026-03-06T07:45:20.003Z
+ * Generated on 2026-03-17T13:15:35.006Z
  *
  */
 import {

--- a/__tests__/fixtures/petstore/types.ts
+++ b/__tests__/fixtures/petstore/types.ts
@@ -3,7 +3,7 @@
  *
  * WARN: Do not edit directly.
  *
- * Generated on 2026-03-06T07:45:20.003Z
+ * Generated on 2026-03-17T13:15:35.006Z
  *
  */
 

--- a/__tests__/fixtures/petstore/valibot.ts
+++ b/__tests__/fixtures/petstore/valibot.ts
@@ -3,7 +3,7 @@
  *
  * WARN: Do not edit directly.
  *
- * Generated on 2026-03-06T07:45:20.003Z
+ * Generated on 2026-03-17T13:15:35.006Z
  *
  */
 import * as v from "valibot";

--- a/__tests__/fixtures/test1/commands.ts
+++ b/__tests__/fixtures/test1/commands.ts
@@ -3,7 +3,7 @@
  *
  * WARN: Do not edit directly.
  *
- * Generated on 2026-03-06T07:45:22.551Z
+ * Generated on 2026-03-17T13:15:38.356Z
  *
  */
 /** eslint-disable max-classes */
@@ -40,6 +40,17 @@ import type {
 } from "./types.js";
 
 /**
+ * Tagged template literal that applies encodeURIComponent to all interpolated values, protecting path integrity from characters like `/` and `#`.
+ * @example encodePath`/users/${userId}` // "/users/foo%2Fbar"
+ */
+function encodePath(
+	strings: TemplateStringsArray,
+	...values: string[]
+): string {
+	return String.raw({ raw: strings }, ...values.map(encodeURIComponent));
+}
+
+/**
  * GetOperationCommand
  *
  */
@@ -51,7 +62,7 @@ export class GetOperationCommand extends Command<
 
 	constructor(input: GetOperationCommandInput) {
 		const { operationId } = input;
-		super(`/operations/${operationId}`);
+		super(encodePath`/operations/${operationId}`);
 	}
 }
 
@@ -94,7 +105,7 @@ export class GetBillingAccountCommand extends Command<
 
 	constructor(input: GetBillingAccountCommandInput) {
 		const { billingAccountId } = input;
-		super(`/billing-accounts/${billingAccountId}`);
+		super(encodePath`/billing-accounts/${billingAccountId}`);
 	}
 }
 
@@ -110,7 +121,10 @@ export class UpdateBillingAccountCommand extends Command<
 
 	constructor(input: UpdateBillingAccountCommandInput) {
 		const { billingAccountId, ...body } = input;
-		super(`/billing-accounts/${billingAccountId}`, jsonStringify(body));
+		super(
+			encodePath`/billing-accounts/${billingAccountId}`,
+			jsonStringify(body),
+		);
 	}
 }
 
@@ -126,7 +140,10 @@ export class GetBillingAccountPortalCommand extends Command<
 
 	constructor(input: GetBillingAccountPortalCommandInput) {
 		const { billingAccountId, ...body } = input;
-		super(`/billing-accounts/${billingAccountId}/portal`, jsonStringify(body));
+		super(
+			encodePath`/billing-accounts/${billingAccountId}/portal`,
+			jsonStringify(body),
+		);
 	}
 }
 
@@ -142,7 +159,10 @@ export class LinkBillingAccountCommand extends Command<
 
 	constructor(input: LinkBillingAccountCommandInput) {
 		const { billingAccountId, ...body } = input;
-		super(`/billing-accounts/${billingAccountId}/link`, jsonStringify(body));
+		super(
+			encodePath`/billing-accounts/${billingAccountId}/link`,
+			jsonStringify(body),
+		);
 	}
 }
 
@@ -158,7 +178,7 @@ export class ListPaymentMethodsCommand extends Command<
 
 	constructor(input: ListPaymentMethodsCommandInput) {
 		const { billingAccountId } = input;
-		super(`/billing-accounts/${billingAccountId}/payment-methods`);
+		super(encodePath`/billing-accounts/${billingAccountId}/payment-methods`);
 	}
 }
 
@@ -174,7 +194,7 @@ export class CreatePaymentMethodCommand extends Command<
 
 	constructor(input: CreatePaymentMethodCommandInput) {
 		const { billingAccountId } = input;
-		super(`/billing-accounts/${billingAccountId}/payment-methods`);
+		super(encodePath`/billing-accounts/${billingAccountId}/payment-methods`);
 	}
 }
 
@@ -191,7 +211,7 @@ export class GetPaymentMethodFromStripeCommand extends Command<
 	constructor(input: GetPaymentMethodFromStripeCommandInput) {
 		const { billingAccountId, stripePaymentMethodId } = input;
 		super(
-			`/billing-accounts/${billingAccountId}/payment-methods/stripe/${stripePaymentMethodId}`,
+			encodePath`/billing-accounts/${billingAccountId}/payment-methods/stripe/${stripePaymentMethodId}`,
 		);
 	}
 }
@@ -209,7 +229,7 @@ export class GetPaymentMethodCommand extends Command<
 	constructor(input: GetPaymentMethodCommandInput) {
 		const { billingAccountId, paymentMethodId } = input;
 		super(
-			`/billing-accounts/${billingAccountId}/payment-methods/${paymentMethodId}`,
+			encodePath`/billing-accounts/${billingAccountId}/payment-methods/${paymentMethodId}`,
 		);
 	}
 }
@@ -227,7 +247,7 @@ export class UpdatePaymentMethodCommand extends Command<
 	constructor(input: UpdatePaymentMethodCommandInput) {
 		const { billingAccountId, paymentMethodId, ...body } = input;
 		super(
-			`/billing-accounts/${billingAccountId}/payment-methods/${paymentMethodId}`,
+			encodePath`/billing-accounts/${billingAccountId}/payment-methods/${paymentMethodId}`,
 			jsonStringify(body),
 		);
 	}
@@ -246,7 +266,7 @@ export class DeletePaymentMethodCommand extends Command<
 	constructor(input: DeletePaymentMethodCommandInput) {
 		const { billingAccountId, paymentMethodId } = input;
 		super(
-			`/billing-accounts/${billingAccountId}/payment-methods/${paymentMethodId}`,
+			encodePath`/billing-accounts/${billingAccountId}/payment-methods/${paymentMethodId}`,
 		);
 	}
 }
@@ -263,7 +283,7 @@ export class ListBillingSubscriptionsCommand extends Command<
 
 	constructor(input: ListBillingSubscriptionsCommandInput) {
 		const { billingAccountId } = input;
-		super(`/billing-accounts/${billingAccountId}/subscriptions`);
+		super(encodePath`/billing-accounts/${billingAccountId}/subscriptions`);
 	}
 }
 
@@ -280,7 +300,7 @@ export class CreateBillingSubscriptionCommand extends Command<
 	constructor(input: CreateBillingSubscriptionCommandInput) {
 		const { billingAccountId, ...body } = input;
 		super(
-			`/billing-accounts/${billingAccountId}/subscriptions`,
+			encodePath`/billing-accounts/${billingAccountId}/subscriptions`,
 			jsonStringify(body),
 		);
 	}
@@ -299,7 +319,7 @@ export class UpdateBillingSubscriptionCommand extends Command<
 	constructor(input: UpdateBillingSubscriptionCommandInput) {
 		const { billingAccountId, subscriptionId, ...body } = input;
 		super(
-			`/billing-accounts/${billingAccountId}/subscriptions/${subscriptionId}`,
+			encodePath`/billing-accounts/${billingAccountId}/subscriptions/${subscriptionId}`,
 			jsonStringify(body),
 		);
 	}
@@ -318,7 +338,7 @@ export class CancelSubscriptionCommand extends Command<
 	constructor(input: CancelSubscriptionCommandInput) {
 		const { billingAccountId, subscriptionId } = input;
 		super(
-			`/billing-accounts/${billingAccountId}/subscriptions/${subscriptionId}`,
+			encodePath`/billing-accounts/${billingAccountId}/subscriptions/${subscriptionId}`,
 		);
 	}
 }
@@ -336,7 +356,7 @@ export class UpdateBillingSubscriptionPromoCodeCommand extends Command<
 	constructor(input: UpdateBillingSubscriptionPromoCodeCommandInput) {
 		const { billingAccountId, subscriptionId, ...body } = input;
 		super(
-			`/billing-accounts/${billingAccountId}/subscriptions/${subscriptionId}/promo-code`,
+			encodePath`/billing-accounts/${billingAccountId}/subscriptions/${subscriptionId}/promo-code`,
 			jsonStringify(body),
 		);
 	}

--- a/__tests__/fixtures/test1/hono-valibot.ts
+++ b/__tests__/fixtures/test1/hono-valibot.ts
@@ -3,7 +3,7 @@
  *
  * WARN: Do not edit directly.
  *
- * Generated on 2026-03-06T07:45:22.551Z
+ * Generated on 2026-03-17T13:15:38.356Z
  *
  */
 

--- a/__tests__/fixtures/test1/main.ts
+++ b/__tests__/fixtures/test1/main.ts
@@ -3,7 +3,7 @@
  *
  * WARN: Do not edit directly.
  *
- * Generated on 2026-03-06T07:45:22.551Z
+ * Generated on 2026-03-17T13:15:38.356Z
  *
  */
 import {

--- a/__tests__/fixtures/test1/types.ts
+++ b/__tests__/fixtures/test1/types.ts
@@ -3,7 +3,7 @@
  *
  * WARN: Do not edit directly.
  *
- * Generated on 2026-03-06T07:45:22.551Z
+ * Generated on 2026-03-17T13:15:38.356Z
  *
  */
 import type { Jsonifiable, Jsonify } from "type-fest";

--- a/__tests__/fixtures/test1/valibot.ts
+++ b/__tests__/fixtures/test1/valibot.ts
@@ -3,7 +3,7 @@
  *
  * WARN: Do not edit directly.
  *
- * Generated on 2026-03-06T07:45:22.551Z
+ * Generated on 2026-03-17T13:15:38.356Z
  *
  */
 import * as v from "valibot";

--- a/lib/hono-valibot.ts
+++ b/lib/hono-valibot.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+import camelcase from "camelcase";
 import type { Project, SourceFile } from "ts-morph";
 import { VariableDeclarationKind } from "ts-morph";
 
@@ -52,7 +53,7 @@ export function createHonoValibotMiddleware(
 		declarationKind: VariableDeclarationKind.Const,
 		declarations: [
 			{
-				name: exportName,
+				name: camelcase(exportName),
 				initializer: (writer) => {
 					writer.write("[");
 					writer.indent(() => {

--- a/lib/process-document.ts
+++ b/lib/process-document.ts
@@ -136,6 +136,30 @@ export async function processOpenApiDocument(
 		moduleSpecifier: "@block65/rest-client",
 	});
 
+	commandsFile.addFunction({
+		name: "encodePath",
+		docs: [
+			{
+				description: wordWrap(
+					"Tagged template literal that applies encodeURIComponent to all interpolated values, protecting path integrity from characters like `/` and `#`.",
+				),
+				tags: [
+					{
+						tagName: "example",
+						text: 'encodePath`/users/${userId}` // "/users/foo%2Fbar"',
+					},
+				],
+			},
+		],
+		parameters: [
+			{ name: "strings", type: "TemplateStringsArray" },
+			{ name: "...values", type: "string[]" },
+		],
+		returnType: "string",
+		statements:
+			"return String.raw({ raw: strings }, ...values.map(encodeURIComponent));",
+	});
+
 	commandsFile.addImportDeclaration({
 		namedImports: ["Jsonifiable"],
 		moduleSpecifier: "type-fest",
@@ -786,9 +810,10 @@ export async function processOpenApiDocument(
 							?.addTypeArgument(queryType.getName());
 					}
 
-					const pathname = `\`${path
-						// .replaceAll(/\{(\w+)\}/g, camelcase)
-						.replaceAll(/{/g, "${")}\``;
+					const hasPathParams = path.includes("{");
+					const pathname = hasPathParams
+						? `encodePath\`${path.replaceAll(/{/g, "${")}\``
+						: `"${path}"`;
 
 					const hasJsonBody = !!jsonBodyType;
 


### PR DESCRIPTION
## Summary
- Add `encodePath` tagged template literal that applies `encodeURIComponent` to interpolated path parameters, preventing `/`, `#`, and other reserved characters from corrupting URL structure
- Fix hono-valibot middleware export names to use camelCase
- Regenerate all test fixtures

## Test plan
- [x] All 4 existing test suites pass
- [x] Verify generated `commands.ts` output uses `encodePath` tag for parameterised paths and plain strings for static paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)