### PR TITLE
fix: resolve $ref schemas for query and header param coercion

### DIFF
--- a/__tests__/__snapshots__/nullables.test.ts.snap
+++ b/__tests__/__snapshots__/nullables.test.ts.snap
@@ -77,6 +77,7 @@ exports[`nullables 1`] = `
 
 exports[`query and header integer params coerce strings to numbers 1`] = `
 "export type Dummy = string;
+export type ExpireTime = number;
 export type ListFilesCommandQuery = {
         exp: \`\${number}\`;
         limit?: \`\${number}\` | undefined;
@@ -92,6 +93,7 @@ exports[`query and header integer params coerce strings to numbers 2`] = `
 "import * as v from "valibot";
 
 export const dummySchema = v.string();
+export const expireTimeSchema = v.pipe(v.number(), v.integer(), v.minValue(0));
 export const listFilesCommandQuerySchema = v.strictObject({
         "exp": v.pipe(v.string(), v.digits(), v.transform((n) => Number.parseInt(n, 10)), v.number(), v.integer(), v.minValue(0)),
         "limit": v.exactOptional(v.pipe(v.string(), v.digits(), v.transform((n) => Number.parseInt(n, 10)), v.number(), v.integer(), v.minValue(1), v.maxValue(100)))

--- a/__tests__/nullables.test.ts
+++ b/__tests__/nullables.test.ts
@@ -113,6 +113,11 @@ test("query and header integer params coerce strings to numbers", async () => {
 		components: {
 			schemas: {
 				Dummy: { type: "string" },
+				ExpireTime: {
+					type: "integer",
+					format: "int64",
+					minimum: 0,
+				},
 			},
 		},
 		paths: {
@@ -125,9 +130,7 @@ test("query and header integer params coerce strings to numbers", async () => {
 							in: "query",
 							required: true,
 							schema: {
-								type: "integer",
-								format: "int64",
-								minimum: 0,
+								$ref: "#/components/schemas/ExpireTime",
 							},
 						},
 						{

--- a/lib/process-document.ts
+++ b/lib/process-document.ts
@@ -407,12 +407,32 @@ export async function processOpenApiDocument(
 							// });
 						}
 
-						if (resolvedParameter.in === "query") {
-							queryParameters.push(resolvedParameter);
-						}
+						if (
+							resolvedParameter.in === "query" ||
+							resolvedParameter.in === "header"
+						) {
+							// Resolve $ref schemas so the valibot coercion
+							// pipeline can inspect the underlying type
+							const resolvedSchema =
+								resolvedParameter.schema &&
+								"$ref" in resolvedParameter.schema
+									? (refs.get(resolvedParameter.schema.$ref) ?? undefined)
+									: undefined;
 
-						if (resolvedParameter.in === "header") {
-							headerParameters.push(resolvedParameter);
+							const paramWithResolvedSchema: oas30.ParameterObject = {
+								...resolvedParameter,
+								...(resolvedSchema &&
+									typeof resolvedSchema === "object" &&
+									!Array.isArray(resolvedSchema) && {
+										schema: resolvedSchema,
+									}),
+							};
+
+							if (resolvedParameter.in === "query") {
+								queryParameters.push(paramWithResolvedSchema);
+							} else {
+								headerParameters.push(paramWithResolvedSchema);
+							}
 						}
 					}
 


### PR DESCRIPTION
## Summary
- When a query/header param schema is a `$ref` (e.g., `$ref: "#/components/schemas/ExpireTime"` with `type: "integer"`), resolve it inline so the string-to-number coercion pipeline applies
- Previously the `$ref` was passed through unchanged, generating `v.number()` which rejected string values from HTTP query strings
- Component schema (`expireTimeSchema`) stays as `v.number()` (correct for non-HTTP contexts); only the query/header param schema gets coercion

## Test plan
- [x] Test updated: `exp` query param now uses `$ref` to `ExpireTime` component schema
- [x] Snapshot confirms coercion pipeline: `v.string() → v.digits() → v.transform(parseInt) → v.number()`
- [x] All 8 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)