### PR TITLE
fix: generate v.null() for type: "null" schemas in valibot

### DIFF
--- a/__tests__/__snapshots__/nullables.test.ts.snap
+++ b/__tests__/__snapshots__/nullables.test.ts.snap
@@ -75,6 +75,13 @@ exports[`nullables 1`] = `
 "
 `;
 
+exports[`oneOf with type null generates v.null() 1`] = `
+"import * as v from "valibot";
+
+export const nullableImageSchema = v.union([v.string(), v.null()]);
+"
+`;
+
 exports[`query and header integer params coerce strings to numbers 1`] = `
 "export type Dummy = string;
 export type ExpireTime = number;

--- a/__tests__/nullables.test.ts
+++ b/__tests__/nullables.test.ts
@@ -103,6 +103,26 @@ test("const values", async () => {
 	expect(result.valibotFile?.getText()).toMatchSnapshot();
 });
 
+test("oneOf with type null generates v.null()", async () => {
+	const result = await processOpenApiDocument(
+		"/tmp/like-you-know-whatever",
+		{
+			openapi: "3.1.0",
+			info: { title: "Test", version: "1.0.0" },
+			paths: {},
+			components: {
+				schemas: {
+					NullableImage: {
+						oneOf: [{ type: "string", format: "uri" }, { type: "null" }],
+					},
+				},
+			},
+		},
+	);
+
+	expect(result.valibotFile.getText()).toMatchSnapshot();
+});
+
 test("query and header integer params coerce strings to numbers", async () => {
 	const schema: oas31.OpenAPIObject = {
 		openapi: "3.1.0",

--- a/lib/valibot.ts
+++ b/lib/valibot.ts
@@ -284,6 +284,10 @@ export function schemaToValidator(
 		return maybeNullable(vcall("strictObject", strictObjectWriter), isNullable);
 	}
 
+	if (schema.type === "null") {
+		return vcall("null");
+	}
+
 	return vcall("unknown");
 }
 


### PR DESCRIPTION
## Summary
- `type: "null"` (OAS 3.1 / JSON Schema 2020-12) now generates `v.null()` instead of `v.unknown()`
- Fixes `oneOf: [{ type: "string" }, { type: "null" }]` pattern generating `v.union([v.string(), v.unknown()])` instead of `v.union([v.string(), v.null()])`

## Test plan
- [x] New test: `oneOf with type null generates v.null()`
- [x] All 9 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)