### PR TITLE
feat: wire header params into Command constructor

### DIFF
--- a/__tests__/__snapshots__/nullables.test.ts.snap
+++ b/__tests__/__snapshots__/nullables.test.ts.snap
@@ -33,6 +33,34 @@ export type UploadDataCommandInput = UploadDataCommandParams;
 `;
 
 exports[`header parameters 2`] = `
+"import { Command } from "@block65/rest-client";
+import type { UploadDataCommandHeader, UploadDataCommandInput, UploadStatus } from "./types.js";
+
+/**
+ * Tagged template literal that applies encodeURIComponent to all interpolated 
+ * values, protecting path integrity from characters like \`/\` and \`#\`.
+ * @example encodePath\`/users/\${userId}\` // "/users/foo%2Fbar"
+ */
+function encodePath(strings: TemplateStringsArray, ...values: string[]): string {
+    return String.raw({ raw: strings }, ...values.map(encodeURIComponent));
+}
+
+/**
+ * UploadDataCommand
+ *
+ */
+export class UploadDataCommand extends Command<UploadDataCommandInput, UploadStatus, never, UploadDataCommandHeader> {
+    public override method = "post" as const;
+
+    constructor(input: UploadDataCommandInput, headers: UploadDataCommandHeader) {
+        const {uploadId } = input;
+        super(encodePath\`/uploads/\${uploadId}\`, undefined, undefined, headers);
+    }
+}
+"
+`;
+
+exports[`header parameters 3`] = `
 "import * as v from "valibot";
 
 export const uploadStatusSchema = v.picklist(["pending", "complete"]);
@@ -47,7 +75,7 @@ export const uploadDataCommandHeaderSchema = v.object({
 "
 `;
 
-exports[`header parameters 3`] = `
+exports[`header parameters 4`] = `
 "import { validator } from "hono/validator";
 import * as v from "valibot";
 import { PublicValibotHonoError } from "@block65/rest-client";

--- a/__tests__/nullables.test.ts
+++ b/__tests__/nullables.test.ts
@@ -280,6 +280,7 @@ test("header parameters", async () => {
 	);
 
 	expect(result.typesFile.getText()).toMatchSnapshot();
+	expect(result.commandsFile.getText()).toMatchSnapshot();
 	expect(result.valibotFile.getText()).toMatchSnapshot();
 	expect(result.honoValibotFile.getText()).toMatchSnapshot();
 });

--- a/lib/process-document.ts
+++ b/lib/process-document.ts
@@ -948,6 +948,19 @@ export async function processOpenApiDocument(
 							?.addTypeArgument(queryType.getName());
 					}
 
+					// headers type argument (4th generic on Command)
+					if (headerType) {
+						// fill in query slot if missing
+						if (!queryType) {
+							commandClassDeclaration
+								.getExtends()
+								?.addTypeArgument(neverKeyword);
+						}
+						commandClassDeclaration
+							.getExtends()
+							?.addTypeArgument(headerType.getName());
+					}
+
 					const hasPathParams = path.includes("{");
 					const pathname = hasPathParams
 						? `encodePath\`${path.replaceAll(/{/g, "${")}\``
@@ -967,7 +980,9 @@ export async function processOpenApiDocument(
 						!isUnspecifiedKeyword(paramsType) &&
 						pathParameters.length > 0;
 
-					if (hasNonJsonBody || hasJsonBody || hasQuery || hasParams) {
+					const hasHeaders = !!headerType && headerParameters.length > 0;
+
+					if (hasNonJsonBody || hasJsonBody || hasQuery || hasParams || hasHeaders) {
 						const ctor = commandClassDeclaration.addConstructor();
 
 						const queryParameterNames = queryParameters
@@ -988,6 +1003,13 @@ export async function processOpenApiDocument(
 								name: "input",
 								type: inputType.getName(),
 							});
+
+							if (hasHeaders) {
+								ctor.addParameter({
+									name: "headers",
+									type: headerType.getName(),
+								});
+							}
 
 							ctor.addStatements([
 								{
@@ -1034,6 +1056,8 @@ export async function processOpenApiDocument(
 							SyntaxKind.CallExpression,
 						);
 
+						const headersArg = hasHeaders ? "headers" : undefined;
+
 						// type narrowing
 						if (Node.isCallExpression(callExpr)) {
 							if (hasJsonBody) {
@@ -1042,7 +1066,10 @@ export async function processOpenApiDocument(
 									`jsonStringify(${inputBodyName})`,
 									...(hasQuery
 										? [`stripUndefined({${queryParameterNames.join(", ")}})`]
-										: []),
+										: hasHeaders
+											? [emptyKeyword]
+											: []),
+									...(headersArg ? [headersArg] : []),
 								]);
 							} else if (hasNonJsonBody) {
 								callExpr.addArguments([
@@ -1050,15 +1077,24 @@ export async function processOpenApiDocument(
 									nonJsonBodyPropName,
 									...(hasQuery
 										? [`stripUndefined({${queryParameterNames.join(", ")}})`]
-										: []),
+										: hasHeaders
+											? [emptyKeyword]
+											: []),
+									...(headersArg ? [headersArg] : []),
 								]);
 							} else if (hasQuery) {
 								callExpr.addArguments([
 									pathname,
 									emptyKeyword,
-									...(hasQuery
-										? [`stripUndefined({${queryParameterNames.join(", ")}})`]
-										: []),
+									`stripUndefined({${queryParameterNames.join(", ")}})`,
+									...(headersArg ? [headersArg] : []),
+								]);
+							} else if (hasHeaders && headersArg) {
+								callExpr.addArguments([
+									pathname,
+									emptyKeyword,
+									emptyKeyword,
+									headersArg,
 								]);
 							} else {
 								callExpr.addArguments([pathname]);


### PR DESCRIPTION
## Summary
- Generated commands with header params get a typed `headers` second constructor arg
- Headers passed as 4th arg to `super()` (requires `@block65/rest-client@12.1.0`)
- 4th generic `CommandHeaders` type arg added to `extends Command<...>`
- Commands without headers are completely unchanged

## Test plan
- [x] Snapshot test shows `constructor(input, headers)` with `super(..., headers)`
- [x] All 9 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)